### PR TITLE
Expose getForEntity and setForEntity outside of methods for server-only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ before_install:
 
 script: 
   - "jshint ."
-  - "velocity test-package ./ --ci"
+  - "./run-tests.sh"

--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -1,1 +1,35 @@
+/* global BoundDocument:false - from dispatch:bound-document */
+
 Configuration.subscription = Meteor.subscribe('__entity_configuration');
+
+/**
+ * Get the configuration object for an entity, extended with all inherited values.
+ *
+ * @param {String} type The type of entity, e.g., 'user'
+ * @param {String} id The entity ID (Currently no support for ObjectId)
+ * @param {Options} options Additional options
+ * @param {Boolean} options.inherit Set to false to retrieve configuration for this entity without going through
+ *                                  inheritance
+ * @param {Boolean} options.bind Set to true to return a bound document which will automatically update the database
+ *                               when modified
+ * @param {Function} callback A callback function that receives error, config. If options.bind == true,
+ *   non-object properties within it will set into the database using the dispatch:bound-document package
+ */
+Configuration.getForEntity = Meteor.wrapAsync(function(type, id, options, callback) {
+  if (typeof options === 'function') {
+    callback = options;
+    options = null;
+  }
+  options = options || {};
+
+  Meteor.call('dispatch:configuration/getForEntity', type, id, _.omit(options, 'bind'), function (error, configDoc) {
+    if (error || !configDoc) {
+      callback(error, configDoc);
+      return;
+    }
+
+    if (options.bind === true) configDoc = new BoundDocument(Configuration.Collection, configDoc);
+
+    callback(null, configDoc.config);
+  });
+});

--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -24,12 +24,13 @@ Configuration.getForEntity = Meteor.wrapAsync(function(type, id, options, callba
 
   Meteor.call('dispatch:configuration/getForEntity', type, id, _.omit(options, 'bind'), function (error, configDoc) {
     if (error || !configDoc) {
-      callback(error, configDoc);
+      if(typeof callback === 'function') callback(error, configDoc);
       return;
     }
 
     if (options.bind === true) configDoc = new BoundDocument(Configuration.Collection, configDoc);
 
-    callback(null, configDoc.config);
+    if(typeof callback === 'function') callback(null, configDoc.config);
+    
   });
 });

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -1,6 +1,5 @@
 /* global SimpleSchema:false - from aldeed:simple-schema */
-/* global MongoObject:false = from aldeed:simple-schema */
-/* global BoundDocument:false - from dispatch:bound-document */
+
 
 Configuration = {};
 
@@ -295,37 +294,7 @@ Configuration.hasDefaultForPrefix = function(prefix) {
   return def.hasOwnProperty(prefix);
 };
 
-/**
- * Get the configuration object for an entity, extended with all inherited values.
- *
- * @param {String} type The type of entity, e.g., 'user'
- * @param {String} id The entity ID (Currently no support for ObjectId)
- * @param {Options} options Additional options
- * @param {Boolean} options.inherit Set to false to retrieve configuration for this entity without going through
- *                                  inheritance
- * @param {Boolean} options.bind Set to true to return a bound document which will automatically update the database
- *                               when modified
- * @param {Function} callback A callback function that receives error, config. If options.bind == true,
- *   non-object properties within it will set into the database using the dispatch:bound-document package
- */
-Configuration.getForEntity = Meteor.wrapAsync(function(type, id, options, callback) {
-  if (typeof options === 'function') {
-    callback = options;
-    options = null;
-  }
-  options = options || {};
 
-  Meteor.call('dispatch:configuration/getForEntity', type, id, _.omit(options, 'bind'), function (error, configDoc) {
-    if (error || !configDoc) {
-      callback(error, configDoc);
-      return;
-    }
-
-    if (options.bind === true) configDoc = new BoundDocument(Configuration.Collection, configDoc);
-
-    callback(null, configDoc.config);
-  });
-});
 
 /* Meteor uses old underscore, so add _.constant */
 _.constant = function(value) {

--- a/lib/server/methods.js
+++ b/lib/server/methods.js
@@ -3,43 +3,9 @@ Meteor.methods({
     if (!Configuration._entityTypeWrite[type](this.userId, id))
       throw new Meteor.Error('access-denied', 'Entity type "write" function prohibited this action');
 
-    options = options || {};
-
-    // If inherit is explicitly false, we only want the actual config for this entity.
-    var configDoc;
-    if (options.inherit === false) {
-      configDoc = Configuration.Collection.findOne(type + '_' + id);
-    } else {
-      var extendList = Configuration._resolveInheritance(type, id, _.omit(options, 'inherit'));
-      configDoc = Configuration._extendEntity(type, id, extendList, null);
-    }
-
-    return configDoc;
+    return Configuration.getForEntity(type, id, options, true);
   },
   'dispatch:configuration/setForEntity': function (type, id, props, overwrite) {
-    // Are we overwriting? Or just updating individual props?
-    var modifier = {};
-
-    if (overwrite) {
-      modifier.$set = {
-        config: props
-      };
-    } else {
-      modifier.$set = new MongoObject({
-        config: props
-      }).getFlatObject({
-        keepArrays: true
-      });
-    }
-
-    modifier.$set.entityType = type;
-    modifier.$set.entityId = id;
-
-    Configuration.Collection.update({
-      _id: type + '_' + id
-    }, modifier, {
-      upsert: true,
-      filter: false
-    });
+    return Configuration.setForEntity(type, id, props, overwrite);
   }
 });

--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -1,3 +1,6 @@
+/* global MongoObject:false = from aldeed:simple-schema */
+
+
 /**
  * Figure out list of entities to extend from based on the inherit() function on each entity
  * definition.
@@ -195,4 +198,46 @@ Configuration.getForEntities = function(entities, options) {
 
   // The above already did the same thing as matchBulkIndices, so no need to run that here.
   return results;
+};
+
+Configuration.getForEntity = function(type, id, options, fullDoc) {
+ options = options || {};
+
+  // If inherit is explicitly false, we only want the actual config for this entity.
+  var configDoc;
+  if (options.inherit === false) {
+    configDoc = Configuration.Collection.findOne(type + '_' + id);
+  } else {
+    var extendList = Configuration._resolveInheritance(type, id, _.omit(options, 'inherit'));
+    configDoc = Configuration._extendEntity(type, id, extendList, null);
+  }
+
+  return fullDoc ? configDoc : configDoc.config;
+};
+
+Configuration.setForEntity = function(type, id, props, overwrite) {
+  // Are we overwriting? Or just updating individual props?
+  var modifier = {};
+
+  if (overwrite) {
+    modifier.$set = {
+      config: props
+    };
+  } else {
+    modifier.$set = new MongoObject({
+      config: props
+    }).getFlatObject({
+      keepArrays: true
+    });
+  }
+
+  modifier.$set.entityType = type;
+  modifier.$set.entityId = id;
+
+  Configuration.Collection.update({
+    _id: type + '_' + id
+  }, modifier, {
+    upsert: true,
+    filter: false
+  });
 };

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'dispatch:configuration',
   summary: 'App configuration manager with inheritance',
-  version: '0.1.5'
+  version: '0.1.6'
 });
 
 Package.onUse(function(api) {

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,1 +1,1 @@
-velocity test-package ./ --port 5000 --driver-package=velocity:html-reporter@0.9.0
+PACKAGE_DIRS=./packages velocity test-package ./ --ci --port 5000 --driver-package=velocity:html-reporter@0.9.0-rc.1 --release METEOR@1.2.0.2


### PR DESCRIPTION
With recent changes, `getForEntity` and `setForEntity` can not be called on the server unless the user is logged in. This change exposes those functions on the server while keeping the authentication check on the client and inside of the method.
- Move existing `getForEntity` to `client.js` (client-only)
- Move meat for `getForEntity` and `setForEntity` methods to `lib/server/server.js`

@aldeed please review.
